### PR TITLE
OTHER-161: Fix try_files statement

### DIFF
--- a/admin/nginx/001-metabrainz
+++ b/admin/nginx/001-metabrainz
@@ -38,7 +38,7 @@ server {
 	location = /robots.txt {
 		root /home/metabrainz/metabrainz-server/root;
 		default_type text/plain;
-		try_files	$uri;
+		try_files $uri =404;
 		expires	1h;
 	}
 


### PR DESCRIPTION
This will try to serve the robots.txt file, or if it's not there it will return a 404
